### PR TITLE
remove comma

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -26,7 +26,7 @@ if master_url is None:
 master_app = 'runestone'
 serving_dir = "./build/StudentCSP"
 dest = '../../static'
-project_name = "StudentCSP",
+project_name = "StudentCSP"
 
 options(
     sphinx = Bunch(docroot=".",),


### PR DESCRIPTION
The spurious comma at the end of the string was making project_name into a tuple which was causing a syntax error in the javascript and causing weird behavior on pages.