### PR TITLE
3_7_5_WSa improved description, scaffolded user

### DIFF
--- a/_sources/CSPNameNumbers/walkAssign.rst
+++ b/_sources/CSPNameNumbers/walkAssign.rst
@@ -135,27 +135,28 @@ We can see values (including the values for named variables) by printing them.  
 .. tabbed:: 3_7_5_WSt
 
         .. tab:: Question
-
+	   Don't click the 'Answer' tab until you've had a go at creating your own solution.
+	   
            10 people went to a restaurant for dinner. Each guest ate 1 appetizer and 1 entree. The whole party shared 1 dessert. Write the code to calculate and print the total *bill* if each appetizer costs $2.00, each entree costs $9.89, and dessert costs $7.99.  It should print 126.89.
-           
+        
+	   Create variables to hold each value.  Calculate ``bill`` as ``(appetizer + entree) * numPeople + dessert``.  Be sure to print the result.
+	
            .. activecode::  3_7_5_WSq
                :nocodelens:
 	       
 	       # Fill in the missing values from the description above
-	       numPeople = 
+	       numPeople = ???
 	       
-	       appetizer = 
-	       entree = 
-	       dessert =
+	       appetizer = ???
+	       entree = ???
+	       dessert = ???
 	       
 	       bill = (??? + ???) * numPeople + ???
 	       
 	       print (bill)
 
         .. tab:: Answer
-        
-            Create variables to hold each value.  Calculate ``totalBill`` as ``appCost + entreeCost + costPerDessert``.  Be sure to print the result.
-            
+                    
             .. activecode::  3_7_5_WSa
                 :nocodelens:
                 

--- a/_sources/CSPNameNumbers/walkAssign.rst
+++ b/_sources/CSPNameNumbers/walkAssign.rst
@@ -140,6 +140,17 @@ We can see values (including the values for named variables) by printing them.  
            
            .. activecode::  3_7_5_WSq
                :nocodelens:
+	       
+	       # Fill in the missing values from the description above
+	       numPeople = 
+	       
+	       appetizer = 
+	       entree = 
+	       dessert =
+	       
+	       bill = (??? + ???) * numPeople + ???
+	       
+	       print (bill)
 
         .. tab:: Answer
         
@@ -148,16 +159,14 @@ We can see values (including the values for named variables) by printing them.  
             .. activecode::  3_7_5_WSa
                 :nocodelens:
                 
-                # DECLARE VARIABLES AND ASSIGN VALUES
-                costPerApp = 2.00
-                costPerEntree = 9.89
-                costPerDessert = 7.99
-                # CREATE FORMULA FOR BILL CALCULATION
-                appCost = costPerApp * 10
-                entreeCost = costPerEntree * 10
-                totalBill = appCost + entreeCost + costPerDessert
-                # PRINT THE RESULT
-                print(totalBill)
+	       numPeople = 10
+	       appetizer = 2
+	       entree = 9.89
+	       dessert = 7.99
+	       
+	       bill = (appetizer + entree) * numPeople + dessert
+	       
+	       print (bill)
                                 
         .. tab:: Discussion 
 


### PR DESCRIPTION
This is the first time the user is asked to generate code themselves, rather than editing an existing solution or rearranging a Parson's problem. As such there is (too much?) unnecessary cognitive load, both in the description and the prescribed answer.

1. The Parson's problem above (the most recent code in the user's mind) uses very simple variable names (bill, total, tip), whereas the answer for this problem has multi-word variables, each of which adds to the 'weight' in the user's mind. 

2. The solution is textually 'dense' with LOTS OF COMMENTS IN CAPS and no vertical spacing, as well as the long variable names.

3. The algorithm exemplified/required is counter-intuitive, especially since the user was recently introduced to parentheses. A much flatter solution would be:

	       bill = (appetizer + entree) * numPeople + dessert

4. The algorithm chosen leads to some potentially confusing variable pairs eg: 
appCost vs costPerApp
entreeCost vs costPerEntree

These nuances of variable naming should be introduced later, not when the user is creating their first ever program. 

5. Added some rubric to explain that the user should attempt the problem first, since they've not seen one of these before. It would probably be better if this were 'broken out' into a separate activity introducing the Question / Answer format, like the others, but you'd probably have to do a chunk more work to make that happen?